### PR TITLE
update docs with new @inner_content

### DIFF
--- a/lib/bamboo_phoenix.ex
+++ b/lib/bamboo_phoenix.ex
@@ -120,7 +120,7 @@ defmodule Bamboo.Phoenix do
           <link rel="stylesheet" href="<%= static_url(MyApp.Endpoint, "/css/email.css") %>">
         </head>
         <body>
-          <%= render @view_module, @view_template, assigns %>
+          <%= @inner_content %>
         </body>
       </html>
 


### PR DESCRIPTION
As of Phoenix 1.5, when using:

`<%= render @view_module, @view_template, assigns %>`

the following warning occurs:

```
warning: Rendering the child template from layouts is deprecated.
Instead of:

    <%= render(@view_module, @view_template, assigns) %>

You should do:

    <%= @inner_content %>
```

Refer to Phoenix 1.5 release notes: https://gist.github.com/chrismccord/e53e79ef8b34adf5d8122a47db44d22f#update-your-layouts

